### PR TITLE
Update paging.ts

### DIFF
--- a/src/lib/paging.ts
+++ b/src/lib/paging.ts
@@ -67,7 +67,7 @@ export async function paging(table: any, index: any, options: Options) {
 
 	const indexProperties = options.elementIndex(options.indexName);
 
-	if (lastEvaluatedKey || (hasLimit && items.length > options.limit)) {
+	if ((lastEvaluatedKey && items.length) || (hasLimit && items.length > options.limit)) {
 		// If we have more data, pop off the last element because it is part of the following page
 		items.pop();
 


### PR DESCRIPTION
From the AWS docs:
"A Query operation can return an empty result set and a LastEvaluatedKey if all the items read for the page of results are filtered out." https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html

Because this filter is missing, the `buildIndex` function could work on an undefined value.